### PR TITLE
SER-1496 Fix Cannot read properties of undefined (reading '$children')

### DIFF
--- a/src/AddressAutocomplete.vue
+++ b/src/AddressAutocomplete.vue
@@ -45,6 +45,8 @@ export default {
     initializeAddressAutocomplete () {
       const refComponent = this.$scopedSlots.default()[0].context.$refs[this.addressAutocompleteRef];
 
+      if (!refComponent) return;
+
       let inputElement;
       if (refComponent.$children && refComponent.$children[0]) {
         inputElement = Object.values(refComponent.$children[0].$refs)[0];


### PR DESCRIPTION
## Error
`Cannot read properties of undefined (reading '$children')`

```js
{snip} default()[0].context.$refs[this.addressAutocompleteRef];e=r.$children&&r.$children[0]?Object.values(r.$children[0].$refs)[0]:r.$refs?Object.v {snip}
```